### PR TITLE
Parallelized_Version

### DIFF
--- a/openpivgui.m
+++ b/openpivgui.m
@@ -472,16 +472,23 @@ if isempty(a) || isempty(b)
 end
 
 switch handles.filesType
+    
     case{'sequence'}
-        for fileind = 1:handles.amount-jump	% main loop, for whole file list
+       tic
+        parfor fileind = 1:handles.amount-jump	% main loop, for whole file list
             openpiv_main_loop(handles, fileind, jump, cropvec,ittWidth,...
     ittHeight,ovlapHor,ovlapVer, prepfun, s2ntype, s2nl, outl, sclt, dt)
         end
+        toc
+        beep
+       
+      %{ 
     case{'pairs'}
-        for fileind = 1:2:handles.amount	% main loop, for whole file list
+        parfor fileind = 1:2:handles.amount	% main loop, for whole file list
             openpiv_main_loop(handles, fileind, 1, cropvec,ittWidth,...
     ittHeight,ovlapHor,ovlapVer, prepfun, s2ntype, s2nl, outl, sclt, dt)
         end
+        %}
     otherwise
         
 end


### PR DESCRIPTION
This is a parallelized version of the GUI-based version of OpenPIV in MATLAB. It has a speed increase roughly proportional to the number of cores on your machine, by using a parfor loop instead of a standard for loop. Some functionality that is lost in this version is that the visual representation of vectors in the GUI is not shown, and the sequential setting of 1-2, 2-3, 3-4 is the only option. The existing option for 1-2, 3-4, 5-6, is not available due to the way parfor works in MATLAB.