### PR TITLE
Patch for pairs/jumps

### DIFF
--- a/openpivgui.m
+++ b/openpivgui.m
@@ -480,15 +480,14 @@ switch handles.filesType
     ittHeight,ovlapHor,ovlapVer, prepfun, s2ntype, s2nl, outl, sclt, dt)
         end
         toc
-        beep
-       
-      %{ 
+             
+      
     case{'pairs'}
-        parfor fileind = 1:2:handles.amount	% main loop, for whole file list
+        for fileind = 1:2:handles.amount	% main loop, for whole file list
             openpiv_main_loop(handles, fileind, 1, cropvec,ittWidth,...
     ittHeight,ovlapHor,ovlapVer, prepfun, s2ntype, s2nl, outl, sclt, dt)
         end
-        %}
+       
     otherwise
         
 end

--- a/openpivgui.m
+++ b/openpivgui.m
@@ -472,16 +472,23 @@ if isempty(a) || isempty(b)
 end
 
 switch handles.filesType
+    
     case{'sequence'}
-        for fileind = 1:handles.amount-jump	% main loop, for whole file list
+       tic
+        parfor fileind = 1:handles.amount-jump	% main loop, for whole file list
             openpiv_main_loop(handles, fileind, jump, cropvec,ittWidth,...
     ittHeight,ovlapHor,ovlapVer, prepfun, s2ntype, s2nl, outl, sclt, dt)
         end
+        toc
+        beep
+       
+      %{ 
     case{'pairs'}
-        for fileind = 1:2:handles.amount	% main loop, for whole file list
+        parfor fileind = 1:2:handles.amount	% main loop, for whole file list
             openpiv_main_loop(handles, fileind, 1, cropvec,ittWidth,...
     ittHeight,ovlapHor,ovlapVer, prepfun, s2ntype, s2nl, outl, sclt, dt)
         end
+        %}
     otherwise
         
 end


### PR DESCRIPTION
Restores option to use pairs and jumps, as well as the GUI functionality when using pairs and jumps. Sequences use a parfor loop, which is typically faster on multi-core computers.